### PR TITLE
Some tiny fixes.

### DIFF
--- a/module/customize.sh
+++ b/module/customize.sh
@@ -29,5 +29,18 @@ if pm list packages | grep -q "com.reveny.vbmetafix.service"; then
     echo "description=Reset the VBMeta digest property with the correct boot hash to fix detection. \nStatus: Active ✅" >> $MODPATH/module.prop
 else
     ui_print "- Install failed. Package not found after installation attempt."
-	echo "description=Reset the VBMeta digest property with the correct boot hash to fix detection. \nStatus: Failed ❌" >> $MODPATH/module.prop
+    echo "description=Reset the VBMeta digest property with the correct boot hash to fix detection. \nStatus: Failed ❌" >> $MODPATH/module.prop
+fi
+
+# Check if /data/adb/tricky_store/target.txt exists and contains the service.
+if [ -f /data/adb/tricky_store/target.txt ]; then
+    if ! grep -q "com.reveny.vbmetafix.service" /data/adb/tricky_store/target.txt; then
+        echo "com.reveny.vbmetafix.service" >> /data/adb/tricky_store/target.txt
+        ui_print "- service added to target.txt"
+    else
+        ui_print "- service exists in target.txt"
+    fi
+else
+    echo "com.reveny.vbmetafix.service" > /data/adb/tricky_store/target.txt
+    ui_print "- target.txt did not exist, Please install Trickystore if not working."
 fi

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -35,6 +35,7 @@ fi
 # Check if /data/adb/tricky_store/target.txt exists and contains the service.
 if [ -f /data/adb/tricky_store/target.txt ]; then
     if ! grep -q "com.reveny.vbmetafix.service" /data/adb/tricky_store/target.txt; then
+        sed -i -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' /data/adb/tricky_store/target.txt;
         echo "com.reveny.vbmetafix.service" >> /data/adb/tricky_store/target.txt
         ui_print "- service added to target.txt"
     else

--- a/module/module.prop
+++ b/module/module.prop
@@ -1,6 +1,6 @@
 id=vbmeta-fixer
 name=VBMeta Fixer
-version=1.0.5
-versionCode=105
-author=Reveny
+version=1.0.6
+versionCode=106
+author=Reveny,AarifZ 
 description=Reset the VBMeta digest property with the correct boot hash to fix detection

--- a/module/module.prop
+++ b/module/module.prop
@@ -2,5 +2,5 @@ id=vbmeta-fixer
 name=VBMeta Fixer
 version=1.0.7
 versionCode=107
-author=Reveny,AarifZ 
+author=Reveny
 description=Reset the VBMeta digest property with the correct boot hash to fix detection

--- a/module/module.prop
+++ b/module/module.prop
@@ -1,6 +1,6 @@
 id=vbmeta-fixer
 name=VBMeta Fixer
-version=1.0.6
-versionCode=106
+version=1.0.7
+versionCode=107
 author=Reveny,AarifZ 
 description=Reset the VBMeta digest property with the correct boot hash to fix detection

--- a/module/service.sh
+++ b/module/service.sh
@@ -32,8 +32,15 @@ while [ $counter -lt $timeout ]; do
     if [ -f "$BOOT_HASH_FILE" ]; then
         boot_hash=$(cat "$BOOT_HASH_FILE")
         if [ "$boot_hash" == "null" ]; then
-            boot_hash=""
-        fi
+        # Check if /data/adb/tricky_store/target.txt exists and contains the service.
+        if [ -f /data/adb/tricky_store/target.txt ]; then
+    if ! grep -q "com.reveny.vbmetafix.service" /data/adb/tricky_store/target.txt; then
+        echo "com.reveny.vbmetafix.service" >> /data/adb/tricky_store/target.txt
+        sleep 5
+        am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService
+    else
+        boot_hash=""
+    fi
         resetprop ro.boot.vbmeta.digest $boot_hash
         
         echo "description=Reset the VBMeta digest property with the correct boot hash to fix detection. \nStatus: Service Active ✅" >> $MODPATH/module.prop

--- a/module/service.sh
+++ b/module/service.sh
@@ -2,6 +2,12 @@ until [ "$(getprop sys.boot_completed)" = "1" ]; do
     sleep 1
 done
 
+# Define paths
+BOOT_HASH_FILE="/data/data/com.reveny.vbmetafix.service/cache/boot.hash"
+TARGET="/data/adb/tricky_store/target.txt"
+timeout=10
+counter=0
+
 # Wait until we are in the launcher
 while true; do
     current_focus=$(dumpsys window | grep -E "mCurrentFocus")
@@ -16,38 +22,26 @@ done
 
 # Delay for 10 seconds which is hopefully enough
 sleep 10
+
 # Remove old to prevent getting applied if generation failed.
 rm -rf $BOOT_HASH_FILE
+
+# Add to target.txt if not already present
+if ! grep -q "com.reveny.vbmetafix.service" "$TARGET"; then
+    sed -i -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' "$TARGET"
+    echo "com.reveny.vbmetafix.service" >> "$TARGET"
+fi
+
 # Run the service
 am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
-
 echo "vbmeta-fixer: service.sh - service started" >> /dev/kmsg
-
-# Define paths
-BOOT_HASH_FILE="/data/data/com.reveny.vbmetafix.service/cache/boot.hash"
-TARGET="/data/adb/tricky_store/target.txt"
-timeout=10
-counter=0
 
 # Attempt to read the boot hash file until it's available or timeout is reached
 while [ $counter -lt $timeout ]; do
     if [ -f "$BOOT_HASH_FILE" ]; then
         boot_hash=$(cat "$BOOT_HASH_FILE")
-        if [ "$boot_hash" = "null" ]; then
-            # Check if the target file contains the service
-            if [ -f "$TARGET" ]; then
-                if ! grep -q "com.reveny.vbmetafix.service" "$TARGET"; then
-                    sed -i -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' "$TARGET"
-                    echo "com.reveny.vbmetafix.service" >> "$TARGET"
-                    sleep 1
-                    am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
-                    sleep 1
-                    boot_hash=$(cat "$BOOT_HASH_FILE")
-                    if [ "$boot_hash" = "null" ]; then
-                    boot_hash=""
-                    fi
-                fi
-            fi
+        if [ "$boot_hash" == "null" ]; then
+            boot_hash=""
         fi
         resetprop ro.boot.vbmeta.digest "$boot_hash"
         

--- a/module/service.sh
+++ b/module/service.sh
@@ -24,6 +24,7 @@ echo "vbmeta-fixer: service.sh - service started" >> /dev/kmsg
 
 # Define the boot hash file path
 BOOT_HASH_FILE="/data/data/com.reveny.vbmetafix.service/cache/boot.hash"
+TARGET="/data/adb/tricky_store/target.txt"
 timeout=5
 counter=0
 
@@ -33,14 +34,18 @@ while [ $counter -lt $timeout ]; do
         boot_hash=$(cat "$BOOT_HASH_FILE")
         if [ "$boot_hash" == "null" ]; then
         # Check if /data/adb/tricky_store/target.txt exists and contains the service.
-        if [ -f /data/adb/tricky_store/target.txt ]; then
-    if ! grep -q "com.reveny.vbmetafix.service" /data/adb/tricky_store/target.txt; then
-        echo "com.reveny.vbmetafix.service" >> /data/adb/tricky_store/target.txt
-        sleep 5
+        if [ -f "$TARGET" ]; then
+        svcheck=$(cat "$TARGET" | grep -q "com.reveny.vbmetafix.service" )
+        if [ "$svcheck" != "thecom.reveny.vbmetafix.service" ]; then
+        sed -i -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' "$TARGET";
+        echo "com.reveny.vbmetafix.service" >> "$TARGET"
+        sleep 1
         am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService
-    else
-        boot_hash=""
-    fi
+        sleep 1
+        boot_hash=$(cat "$BOOT_HASH_FILE")
+        fi
+        fi
+        fi
         resetprop ro.boot.vbmeta.digest $boot_hash
         
         echo "description=Reset the VBMeta digest property with the correct boot hash to fix detection. \nStatus: Service Active ✅" >> $MODPATH/module.prop

--- a/module/service.sh
+++ b/module/service.sh
@@ -19,7 +19,7 @@ sleep 10
 # Remove old to prevent getting applied if generation failed.
 rm -rf $BOOT_HASH_FILE
 # Run the service
-am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0
+am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
 
 echo "vbmeta-fixer: service.sh - service started" >> /dev/kmsg
 
@@ -40,9 +40,12 @@ while [ $counter -lt $timeout ]; do
                     sed -i -e ':a' -e '/^\n*$/{$d;N;};/\n$/ba' "$TARGET"
                     echo "com.reveny.vbmetafix.service" >> "$TARGET"
                     sleep 1
-                    am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService
+                    am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
                     sleep 1
                     boot_hash=$(cat "$BOOT_HASH_FILE")
+                    if [ "$boot_hash" = "null" ]; then
+                    boot_hash=""
+                    fi
                 fi
             fi
         fi
@@ -54,7 +57,7 @@ while [ $counter -lt $timeout ]; do
     else
         sleep 1
         if [ -d "/data/data/com.reveny.vbmetafix.service/cache" ]; then
-        am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0
+        am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
         fi
         counter=$((counter + 1))
     fi

--- a/module/service.sh
+++ b/module/service.sh
@@ -16,7 +16,8 @@ done
 
 # Delay for 10 seconds which is hopefully enough
 sleep 10
-
+# Remove old to prevent getting applied if generation failed.
+rm -rf $BOOT_HASH_FILE
 # Run the service
 am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0
 

--- a/module/service.sh
+++ b/module/service.sh
@@ -18,14 +18,14 @@ done
 sleep 10
 
 # Run the service
-am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService
+am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0
 
 echo "vbmeta-fixer: service.sh - service started" >> /dev/kmsg
 
 # Define paths
 BOOT_HASH_FILE="/data/data/com.reveny.vbmetafix.service/cache/boot.hash"
 TARGET="/data/adb/tricky_store/target.txt"
-timeout=5
+timeout=10
 counter=0
 
 # Attempt to read the boot hash file until it's available or timeout is reached
@@ -52,6 +52,9 @@ while [ $counter -lt $timeout ]; do
         break
     else
         sleep 1
+        if [ -d "/data/data/com.reveny.vbmetafix.service/cache" ]; then
+        am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0
+        fi
         counter=$((counter + 1))
     fi
 done


### PR DESCRIPTION
Some basic changes.
- Check and add com.reveny.vbmetafix.service to Target.txt fixing empty digest for Broken TEE.
- Delete boot.hash before generating new one to avoid mismatch of disgest in some cases.
- Add Execution flags to better support APatch. 
 - APatchNext might still need to fix it's cmd: Failure calling service activity: Failed transaction (2147483646)