### PR TITLE
Fix start service

### DIFF
--- a/module/service.sh
+++ b/module/service.sh
@@ -36,20 +36,20 @@ while true; do
         update_status "Launcher detected (via activities)" "⏳"
         break
     fi
-    
+
     if dumpsys activity recents | grep -q "Recent #0" | grep -q -E "launcher|Launcher|lawnchair"; then
         echo "vbmeta-fixer: service.sh - launcher detected via recents" >> /dev/kmsg
         update_status "Launcher detected (via recents)" "⏳"
         break
     fi
-    
+
     launcher_counter=$((launcher_counter + 1))
     if [ $launcher_counter -gt $launcher_timeout ]; then
         echo "vbmeta-fixer: service.sh - launcher detection timed out after ${launcher_timeout}s, continuing anyway" >> /dev/kmsg
         update_status "Launcher timeout, continuing" "⚠️"
         break
     fi
-    
+
     sleep 1
     echo "vbmeta-fixer: service.sh - waiting for launcher to start (${launcher_counter}/${launcher_timeout}s)" >> /dev/kmsg
 done
@@ -88,9 +88,9 @@ while [ $counter -lt $timeout ]; do
         else
             echo "vbmeta-fixer: service.sh - hash file loaded successfully" >> /dev/kmsg
         fi
-        
+
         update_status "Setting VBMeta properties" "⏳"
-        
+
         # Set all VBMeta properties
         resetprop ro.boot.vbmeta.digest "$boot_hash"
         resetprop ro.boot.vbmeta.hash_alg "sha256"
@@ -104,7 +104,7 @@ while [ $counter -lt $timeout ]; do
 
         resetprop ro.boot.vbmeta.invalidate_on_error "yes"
         resetprop ro.boot.vbmeta.device_state "locked"
-        
+
         update_status "Service Active" "✅"
         echo "vbmeta-fixer: service.sh - service active and properties set" >> /dev/kmsg
         break

--- a/module/service.sh
+++ b/module/service.sh
@@ -89,12 +89,8 @@ while [ $count -lt $retry_count ]; do
         echo "vbmeta-fixer: service.sh - service active and properties set" >> /dev/kmsg
         break
     else
-        if [ -d "/data/data/com.reveny.vbmetafix.service/cache" ]; then
-            echo "vbmeta-fixer: service.sh - cache directory exists, restarting service" >> /dev/kmsg
-            am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
-        else
-            echo "vbmeta-fixer: service.sh - waiting for cache directory to be created ($count/$retry_count)" >> /dev/kmsg
-        fi
+        am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
+        echo "vbmeta-fixer: service.sh - restarting service ($count/$retry_count)" >> /dev/kmsg
         count=$((count + 1))
         sleep 1
     fi

--- a/module/service.sh
+++ b/module/service.sh
@@ -36,7 +36,7 @@ done
 update_status "Unlocked ready, stabilizing system" "⏳"
 sleep 10
 
-rm -rf $BOOT_HASH_FILE
+rm -f $BOOT_HASH_FILE
 update_status "Starting service" "⏳"
 
 # Add to target.txt if not already present

--- a/module/service.sh
+++ b/module/service.sh
@@ -57,6 +57,7 @@ fi
 am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
 echo "vbmeta-fixer: service.sh - service started" >> /dev/kmsg
 update_status "Service started, waiting for hash file" "⏳"
+sleep 5
 
 while [ $count -lt $retry_count ]; do
     if [ -f "$BOOT_HASH_FILE" ]; then

--- a/module/service.sh
+++ b/module/service.sh
@@ -89,7 +89,6 @@ while [ $count -lt $retry_count ]; do
         echo "vbmeta-fixer: service.sh - service active and properties set" >> /dev/kmsg
         break
     else
-        sleep 1
         if [ -d "/data/data/com.reveny.vbmetafix.service/cache" ]; then
             echo "vbmeta-fixer: service.sh - cache directory exists, restarting service" >> /dev/kmsg
             am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
@@ -97,6 +96,7 @@ while [ $count -lt $retry_count ]; do
             echo "vbmeta-fixer: service.sh - waiting for cache directory to be created ($count/$retry_count)" >> /dev/kmsg
         fi
         count=$((count + 1))
+        sleep 1
     fi
 done
 

--- a/module/service.sh
+++ b/module/service.sh
@@ -36,7 +36,7 @@ done
 update_status "Unlocked ready, stabilizing system" "⏳"
 sleep 10
 
-rm -rf "$(dirname "$BOOT_HASH_FILE")"
+rm -rf $BOOT_HASH_FILE
 update_status "Starting service" "⏳"
 
 # Add to target.txt if not already present

--- a/module/service.sh
+++ b/module/service.sh
@@ -36,7 +36,7 @@ done
 update_status "Unlocked ready, stabilizing system" "⏳"
 sleep 10
 
-rm -rf $BOOT_HASH_FILE
+rm -rf "$(dirname "$BOOT_HASH_FILE")"
 update_status "Starting service" "⏳"
 
 # Add to target.txt if not already present

--- a/module/service.sh
+++ b/module/service.sh
@@ -15,8 +15,8 @@ update_status() {
 
 BOOT_HASH_FILE="/data/data/com.reveny.vbmetafix.service/cache/boot.hash"
 TARGET="/data/adb/tricky_store/target.txt"
-timeout=10
-counter=0
+retry_count=10
+count=0
 
 update_status "Initializing" "⏳"
 
@@ -58,7 +58,7 @@ am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user
 echo "vbmeta-fixer: service.sh - service started" >> /dev/kmsg
 update_status "Service started, waiting for hash file" "⏳"
 
-while [ $counter -lt $timeout ]; do
+while [ $count -lt $retry_count ]; do
     if [ -f "$BOOT_HASH_FILE" ]; then
         boot_hash=$(cat "$BOOT_HASH_FILE")
         if [ "$boot_hash" == "null" ]; then
@@ -93,16 +93,16 @@ while [ $counter -lt $timeout ]; do
             echo "vbmeta-fixer: service.sh - cache directory exists, restarting service" >> /dev/kmsg
             am start-foreground-service -n com.reveny.vbmetafix.service/.FixerService --user 0 </dev/null 1>/dev/null 2>&1
         else
-            echo "vbmeta-fixer: service.sh - waiting for cache directory to be created ($counter/$timeout)" >> /dev/kmsg
+            echo "vbmeta-fixer: service.sh - waiting for cache directory to be created ($count/$retry_count)" >> /dev/kmsg
         fi
-        counter=$((counter + 1))
+        count=$((count + 1))
     fi
 done
 
 # Check if we timed out
-if [ $counter -ge $timeout ]; then
+if [ $count -ge $retry_count ]; then
     update_status "Failed to set VBMeta properties" "❌"
-    echo "vbmeta-fixer: service.sh - failed to reset VBMeta digest within timeout" >> /dev/kmsg
+    echo "vbmeta-fixer: service.sh - failed to reset VBMeta digest within retries count" >> /dev/kmsg
 fi
 
 echo "vbmeta-fixer: service.sh - script completed" >> /dev/kmsg


### PR DESCRIPTION
修复 https://github.com/reveny/Android-VBMeta-Fixer/issues/23

- [x] 修复重新开机后必须马上解锁才能启动服务的问题
- [x] 通过检测 `/sdcard/Android` 来判断是否解锁手机
- [x] 修复重试逻辑
- [x] 变量命名优化，代码多余空格清理

<img width="1068" height="676" alt="捕获" src="https://github.com/user-attachments/assets/4a866392-6a19-4c0f-8640-3f9634dd458f" />
